### PR TITLE
Update CAN rx filters

### DIFF
--- a/CANModule.cpp
+++ b/CANModule.cpp
@@ -123,26 +123,6 @@ void CANModule::initializeCAN() {
         mcp2515.init_Filt(0, 0, FILTER_SC);            // init_Filt(filter number, 0 for standard mode, filter used to accept a matching ID) - Filter 1
     #endif
 
-    #ifdef FILTER_EC
-        mcp2515.init_Filt(1, 0, FILTER_EC);
-    #endif
-
-    #ifdef FILTER_CC
-        mcp2515.init_Filt(2, 0, FILTER_CC);
-    #endif
-
-    #ifdef FILTER_F1
-        mcp2515.init_Filt(3, 0, FILTER_F1);
-    #endif
-
-    #ifdef FILTER_F2
-        mcp2515.init_Filt(4, 0, FILTER_F2);
-    #endif
-
-    #ifdef FILTER_F3
-        mcp2515.init_Filt(5, 0, FILTER_F3);
-    #endif
-
     mcp2515.setMode(MCP_NORMAL);                              // Change to normal mode to allow messages to be transmitted
     pinMode(INT_PIN, INPUT);                                  // Interrupt pin triggered by SLAVE (CAN Adapter) to ask MASTER to initiate SPI communication
     pinMode(SPI_CS_PIN, OUTPUT);                              // Chip select pin for CAN module

--- a/CANModule.h
+++ b/CANModule.h
@@ -37,11 +37,6 @@
 #define MASK0 0x07FF0000                    // Mask0 for Filter 0 and Filter 1
 #define MASK1 0x07FF0000                    // Mask1 for Filters 2, 3,4 and 5 (there are only 6 filters total. See explanation at: https://forum.arduino.cc/t/mcp2515-can-filtering/506401 )
 #define FILTER_SC 0x01000000                // Acceptance filter for ID 0x100 (Supervisory Controller - Raspberry Pi)
-#define FILTER_EC 0x01010000                // Acceptance filter for ID 0x101 (Elevator Controller) -- comment out if only want to accept commands from Supervisory controller
-#define FILTER_CC 0x02000000                // Acceptance filter for ID 0x200 (Car Controller)
-#define FILTER_F1 0x02010000                // Acceptance filter for ID 0x201 (Floor 1 Controller)
-#define FILTER_F2 0x02020000                // Acceptance filter for ID 0x202 (Floor 2 Controller)
-#define FILTER_F3 0x02030000                // Acceptance filter for ID 0x203 (Floor 3 Controller)
 
 class CANModule {
 public:


### PR DESCRIPTION
- Remove filters to accept messages from other parts of the system. The elevator controller will only accept messages from the supervisory controller now.